### PR TITLE
Fixing _result to use the underscore method

### DIFF
--- a/backbone.basicauth.js
+++ b/backbone.basicauth.js
@@ -47,7 +47,7 @@
    */
   Backbone.sync = function (method, model, options) {
     // Handle both string and function urls
-    var remoteURL = _result(model, 'url');
+    var remoteURL = _.result(model, 'url');
 
     // Retrieve the auth credentials from the model url
     var credentials = remoteURL.match(/\/\/(.*):(.*)@/),


### PR DESCRIPTION
The newest version of this project doesn't seem to work properly - _result is not defined.

I'm pretty sure we should be referencing underscore.js' _.result function.
