### PR TITLE
Add a defaultCredentials so that all sync method will use it if no model credentials are set

### DIFF
--- a/backbone.basicauth.js
+++ b/backbone.basicauth.js
@@ -43,7 +43,8 @@
       return {
         'Authorization': 'Basic ' + encode(credentials)
       };
-    }
+    },
+    defaultCredentials: false
   };
 
   // Store a copy of the original Backbone.sync
@@ -63,6 +64,11 @@
 
     // Basic Auth supports two modes: URL-based and function-based.
     var credentials, remoteUrl, remoteUrlParts;
+
+    // If there is no credentials on the model check if there is a fallback.
+    if (!model.credentials && Backbone.BasicAuth.defaultCredentials != false) {
+      model.credentials = Backbone.BasicAuth.defaultCredentials;
+    }
 
     if(model.credentials) {
       // Try function-based.


### PR DESCRIPTION
Hi,

I'm using this library on a project and it was working perfectly until I called mycollection.create({...}). The collection create the model but eventually doesn't add the credentials to the new model, even if the collection has the credentials. I could have created the model and manually assigned credentials to it before calling the create method, but I didn't like this solution.

Instead, I added a `Backbone.BasicAuth.defaultCredentials` variable. If this is defined and the model or collection doesn't have a credential then the defaultCredentials will be used.
