### PR TITLE
make options optional like default Backbone.sync

### DIFF
--- a/backbone.basicauth.js
+++ b/backbone.basicauth.js
@@ -60,6 +60,7 @@
    * @return {object}         Reference to Backbone.sync for chaining
    */
   Backbone.sync = function (method, model, options) {
+    options = options || {};
 
     // Basic Auth supports two modes: URL-based and function-based.
     var credentials, remoteUrl, remoteUrlParts;


### PR DESCRIPTION
Hi,

The options parameter from the default Backbone.sync method is optional. So if an app use Backbone.sync("update", my_collection), adding this library will break it. This pull request simply add one line which make it work again.

edit: For reference, here is where the backbone.sync method make the default options http://backbonejs.org/docs/backbone.html#section-132
