### PR TITLE
Add credentials.token option for 'remember me' style authentication persistance

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,19 @@ model.credentials = function() {
 	};
 };
 
+// or ...
+model.credentials = function() {
+  return {
+    token: window.localStorage.token
+  };
+};
+
 model.fetch();
 ```
 
 This mode is good for authentication that may change when the app is used, e.g. if different users are able to authenticate with the app. The credentials can be hard coded or set dynamically.
+
+The token can be set directly on the model if store locally using a localStorage or cookie based `remember me` style authentication strategy.
 
 This mode is the most flexible. If you are unsure which mode to use, try this one first.
 
@@ -89,6 +98,26 @@ $.ajax({
   	password: 'pass'
 	})
 });
+
+```
+
+## Saving the access token for `remember me` style authentication
+
+If your application requires the ability to remember login credentials, saving the Base64 encoded token to localStorage or a cookie is a better option than storing the username and password directly.
+
+If you need/want to do this, there is a convenience function which will help you allow you to encode and store the token locally: `Backbone.BasicAuth.getToken()`.
+
+Example:
+
+``` js
+// Set the credenials on the users account model and store the token
+account.credentials = {
+  password: password,
+  username: username
+};
+account.credentials.token = Backbone.BasicAuth.getToken(account.credentials)
+
+if (window.localStorage) window.localStorage.token = account.credentials.token;
 
 ```
 

--- a/backbone.basicauth.js
+++ b/backbone.basicauth.js
@@ -40,9 +40,16 @@
   // Add a public method so that anything else can also create the header
   Backbone.BasicAuth = {
     getHeader: function(credentials) {
+      // Check for an existing token paramater to allow locally stored tokens
+      // Example: LocalStoarge, Cookies
+      var token = credentials.token || encode(credentials);
       return {
-        'Authorization': 'Basic ' + encode(credentials)
+        'Authorization': 'Basic ' + token
       };
+    },
+    // Public method for encoding credentials from email/token
+    getToken: function(credentials) {
+      return encode(credentials);
     }
   };
 


### PR DESCRIPTION
I'm not sure how many people would find this useful, but we need a persistance strategy for our application to 'remember' user logins.  Storing the encoded token locally seemed to be the best solution, so this PR adds that ability, plus a new public method to get the encoded token.
