### PR TITLE
Not to expose password on browser console...

### DIFF
--- a/backbone.basicauth.js
+++ b/backbone.basicauth.js
@@ -39,9 +39,11 @@
 
   // Add a public method so that anything else can also create the header
   Backbone.BasicAuth = {
+    encode: encode,
     getHeader: function(credentials) {
+      var auth = typeof credentials == 'object' ? encode(credentials) : credentials;
       return {
-        'Authorization': 'Basic ' + encode(credentials)
+        'Authorization': 'Basic ' + auth
       };
     }
   };


### PR DESCRIPTION
I was using this in our project. it was working great.
We were storing username and password as object to sessionstorage and in model.credentials.
The issue came around: one can get the raw password, so issue is to protect the password to be exposed.
I came around and found a solution that can protect the password.
We will store base64 encoded user:pass: thus the issue solved.

Use of string(base64) credential, for security we dont want to expose raw password. Storing the encoded credentials and using them on demand.
store in session
var cred = Backbone.BasicAuth.encode({
                username: user,
                password: pw
            });
            sessionStorage.setItem('credentials',cred);
            this.model.credentials = cred;

using Backbone.BasicAuth.getHeader(sessionStorage.getItem('credentials'));

Thanks